### PR TITLE
POM maven plugin version fix

### DIFF
--- a/src/docbkx/advanced/maven/jetty-maven-helloworld.xml
+++ b/src/docbkx/advanced/maven/jetty-maven-helloworld.xml
@@ -135,7 +135,7 @@ public class HelloWorld extends AbstractHandler
   <name>Jetty HelloWorld</name>
 
   <properties>
-    <jettyVersion>9.0.0</jettyVersion>
+      <jettyVersion>9.0.2.v20130417</jettyVersion> /// Adapt this to a version found on http://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-maven-plugin/
   </properties>
 
   <dependencies>
@@ -294,7 +294,7 @@ public class HelloServlet extends HttpServlet
   <name>Jetty HelloWorld WebApp</name>
 
   <properties>
-    <jettyVersion>9.0.0</jettyVersion>
+      <jettyVersion>9.0.2.v20130417</jettyVersion> /// Adapt this to a version found on http://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-maven-plugin/
   </properties>
 
   <dependencies>


### PR DESCRIPTION
I hope this is correct. Please tell me otherwise.

With the version of the current documentation, `mvn jetty:run` failed.
With my changes, it works.
