### PR TITLE
Update Documentation after Bug 414885

### DIFF
--- a/src/docbkx/reference/architecture/jetty-classloading.xml
+++ b/src/docbkx/reference/architecture/jetty-classloading.xml
@@ -288,6 +288,18 @@
 
               <entry>Do hide all other Jetty classes.</entry>
             </row>
+
+            <row>
+              <entry>org.apache.jasper.</entry>
+
+              <entry>Do hide Jasper JSP implementation classes.</entry>
+            </row>
+
+            <row>
+              <entry>org.eclipse.jdt.</entry>
+
+              <entry>Do hide JDT compiler classes.</entry>
+            </row>
           </tbody>
         </tgroup>
       </table>


### PR DESCRIPTION
Update the class loading documentation so that is correct after 414885
has been fixed.
- `org.apache.jasper.` is hidden by default
- `org.eclipse.jdt.` is hidden by default

https://bugs.eclipse.org/bugs/show_bug.cgi?id=414885
