### PR TITLE
fixed incorrect documentation, webappconfig should be web app

### DIFF
--- a/src/docbkx/reference/jetty-xml/override-web-xml.xml
+++ b/src/docbkx/reference/jetty-xml/override-web-xml.xml
@@ -106,10 +106,10 @@ import org.eclipse.jetty.webapp.WebAppContext;
             ...
             <artifactId>jetty-maven-plugin</artifactId>
             <configuration>
-                <webAppConfig>
+                <webApp>
                   ...
                   <overrideDescriptor>src/main/resources/override-web.xml</overrideDescriptor>
-                </webAppConfig>
+                </webApp>
             </configuration>
         </plugin>
         ...


### PR DESCRIPTION
in the example configuration for maven the configuration element should be 'webApp' not 'webAppConfig'

I've fixed this for the override xml as this is the one that I was using when I found the error.

It also looks like the same error is in two other files, but I have not modified them as I have not tested if  these are broken as well:
https://github.com/jetty-project/jetty-documentation/blob/063695ec030e83cbb3d06e4182334b4c19a77e44/src/docbkx/reference/jetty-xml/webdefault-xml.xml
https://github.com/jetty-project/jetty-documentation/blob/0815a8856020fbad1d085f0fd6c802a6cdd8a9e6/src/docbkx/administration/sessions/using-persistent-sessions.xml

I can update these as well if you want but I have not tested to confirm correctness
