### PR TITLE
configure ssl section 'Configuring SslContextFactory' amended  

### DIFF
--- a/src/docbkx/configuring/connectors/configuring-ssl.xml
+++ b/src/docbkx/configuring/connectors/configuring-ssl.xml
@@ -489,6 +489,23 @@ $ openssl pkcs12 -export -inkey example.key -in cert-chain.txt -out example.pkcs
       <para>The keyManagerPassword is passed as the password arg to KeyManagerFactory.init(...). If there is no
           keymanagerpassword, then the keystorepassword is used instead. If there is no trustmanager set, then the
           keystore is used as the trust store and the keystorepassword is used as the truststore password</para>
+          
+      <para>There is no need to create a new instance of SslContextFactory using the xml above as one exists in jetty-ssl.xml. 
+          Edit the paths and passwords in jetty-ssl.xml and ensure you add following lines to start.ini after 
+          the line jetty.dump.stop=:</para>
+          
+      <informalexample>
+        <programlisting language="plain"><![CDATA[
+          etc/jetty-ssl.xml
+		  etc/jetty-https.xml]]></programlisting></informalexample>
+		  
+	  <para>Optionally, configure the https port either in jetty-https.xml like this:
+		  <informalexample>
+        <programlisting language="xml"><![CDATA[<Set name="port">8443</Set>]]></programlisting>
+      </informalexample>
+		  or via the commandline e.g. 
+		  <screen><![CDATA[$ java -jar start.jar https.port=8443]]></screen>
+		  </para>
     </section>
 
       <section xml:id="configuring-sslcontextfactory-cipherSuites">


### PR DESCRIPTION
the current docs did need some tightening, i was stuck on this for a while and am providing an update to the docs

this was from my query on http://stackoverflow.com/questions/22272991/jetty-9-1-2-ssl-configuration-as-per-documentation-not-working
