### PR TITLE
fix git clone URL to right path.

### DIFF
--- a/src/docbkx/reference/contributing/documentation.xml
+++ b/src/docbkx/reference/contributing/documentation.xml
@@ -79,7 +79,7 @@
 
     <screen linenumbering="numbered"><![CDATA[
 
-$ git clone git@github.com:jetty-project/jetty-documentation.git
+$ git clone https://github.com/jetty-project/jetty-documentation.git
       
     ]]></screen>
 


### PR DESCRIPTION
original one in document doesn't work. 
