### PR TITLE
Corrected Class package

### DIFF
--- a/src/docbkx/administration/sessions/using-persistent-sessions.xml
+++ b/src/docbkx/administration/sessions/using-persistent-sessions.xml
@@ -53,9 +53,9 @@
   .
   .
   <Set name="sessionHandler">
-    <New class="org.eclipse.jetty.servlet.SessionHandler">
+    <New class="org.eclipse.jetty.server.session.SessionHandler">
       <Arg>
-        <New class="org.eclipse.jetty.servlet.HashSessionManager">
+        <New class="org.eclipse.jetty.server.session.HashSessionManager">
           <Set name="storeDirectory">your/chosen/directory/goes/here</Set>
         </New>
       </Arg>
@@ -103,9 +103,9 @@
 
     <informalexample>
       <programlisting language="xml"><![CDATA[<Set name="sessionHandler">
-  <New class="org.eclipse.jetty.servlet.SessionHandler">
+  <New class="org.eclipse.jetty.server.session.SessionHandler">
     <Arg>
-      <New class="org.eclipse.jetty.servlet.HashSessionManager">
+      <New class="org.eclipse.jetty.server.session.HashSessionManager">
         <Set name="lazyLoad">true</Set>
       </New>
     </Arg>


### PR DESCRIPTION
SessionHandler and HashSessionManager both reside in org.eclipse.jetty.server.session package as can be seen here: 
http://download.eclipse.org/jetty/stable-9/apidocs/org/eclipse/jetty/server/session/HashSessionManager.html
http://download.eclipse.org/jetty/stable-9/apidocs/org/eclipse/jetty/server/session/SessionHandler.html
