### PR TITLE
Correct the example of how to set the web application request log

### DIFF
--- a/src/docbkx/administration/logging/configuring-jetty-request-logs.xml
+++ b/src/docbkx/administration/logging/configuring-jetty-request-logs.xml
@@ -140,7 +140,7 @@ requestLogHandler.setRequestLog(requestLog);   ]]></programlisting>
     <New id="RequestLog" class="org.eclipse.jetty.server.handler.RequestLogHandler">
       <Set name="requestLog">
         <New id="RequestLogImpl" class="org.eclipse.jetty.server.NCSARequestLog">
-          <Set name="filename"><Property name="jetty.logs" default="./logs"/>/test-yyyy_mm_dd.request.log</Arg>
+          <Set name="filename"><Property name="jetty.logs" default="./logs"/>/test-yyyy_mm_dd.request.log</Set>
           <Set name="filenameDateFormat">yyyy_MM_dd</Set>
           <Set name="LogTimeZone">GMT</Set>
           <Set name="retainDays">90</Set>


### PR DESCRIPTION
There is a mismatch on the closing tag on the example within the 'Configuring a Separate Request Log For a Web Application'. This pull request fixes this.