### PR TITLE
Jetty-Maven-Plugin example used 8.x config key

### DIFF
--- a/src/docbkx/reference/jetty-xml/webdefault-xml.xml
+++ b/src/docbkx/reference/jetty-xml/webdefault-xml.xml
@@ -111,10 +111,10 @@ import org.eclipse.jetty.webapp.WebAppContext;
             ...
             <artifactId>jetty-maven-plugin</artifactId>
             <configuration>
-                <webAppConfig>
+                <webApp>
                   ...
                   <defaultsDescriptor>/my/path/to/webdefault.xml</defaultsDescriptor>
-                </webAppConfig>
+                </webApp>
             </configuration>
         </plugin>
         ...


### PR DESCRIPTION
Old version of the example doesn't seem to work anymore with `jetty-maven-plugin` 9.2.10