### PR TITLE
Update http-client-other.xml

### DIFF
--- a/src/docbkx/development/clients/http/http-client-other.xml
+++ b/src/docbkx/development/clients/http/http-client-other.xml
@@ -154,14 +154,15 @@ HttpProxy proxy = new HttpProxy("proxyHost", proxyPort);
 // Do not proxy requests for localhost:8080
 proxy.getExcludedAddresses().add("localhost:8080");
 
-httpClient.setProxyConfiguration(proxyConfig);
+// add the new proxy to the list of proxies already registered
+proxyConfig.getProxies().add(proxy);
 
 ContentResponse response = httpClient.GET(uri);
 ]]>
       </programlisting>
     </informalexample>
     <para>You specify the proxy host and port, and optionally also the addresses that you do not want to be proxied,
-    and then set the proxy configuration on the <code>HttpClient</code> instance.</para>
+    and then add the proxy configuration on the <code>ProxyConfiguration</code> instance.</para>
     <para>Configured in this way, <code>HttpClient</code> makes requests to the HTTP proxy (for plain-text HTTP
     requests) or establishes a tunnel via HTTP CONNECT (for encrypted HTTPS requests).</para>
   </section>


### PR DESCRIPTION
The Proxy Support documentation was outdated because Jetty 9 behaves different. Adjusted the example and description.