### PR TITLE
provide example value for contextPath setting

### DIFF
--- a/src/docbkx/development/maven/jetty-maven-plugin.xml
+++ b/src/docbkx/development/maven/jetty-maven-plugin.xml
@@ -512,7 +512,7 @@
 
               <listitem>
                 <para>The context path for your webapp. By default, this is
-                set to <code>/</code>.</para>
+                set to <code>/</code>. If using a custom value for this parameter, you probably want to include the leading <code>/</code>, example <code>/mycontext</code>.</para>
               </listitem>
             </varlistentry>
 


### PR DESCRIPTION
Adding explicit instructions for including leading '/' in contextPath config values. 