### PR TITLE
Correct typo in startup-overview.xml

### DIFF
--- a/src/docbkx/administration/startup/startup-overview.xml
+++ b/src/docbkx/administration/startup/startup-overview.xml
@@ -71,7 +71,7 @@
 
         <para>If you want to modify the Jetty distribution, base and
         home can be the same directory. Separating the base and home
-        directories allows the distribution to remain unmodified, with all customizations in the the home directory, and thus
+        directories allows the distribution to remain unmodified, with all customizations in the base directory, and thus
         simplifies subsequent server version upgrades.</para>
       </listitem>
     </varlistentry>


### PR DESCRIPTION
Corrected typo in paragraph "Resolving Server Filesystem Locations": all customizations are in the ${jetty.base} directory NOT in the ${jetty.home} directory as described earlier in the same paragraph.