### PR TITLE
update GITBROWSEURL

### DIFF
--- a/src/main/filters/jetty.properties
+++ b/src/main/filters/jetty.properties
@@ -1,4 +1,4 @@
 JDURL http://download.eclipse.org/jetty/stable-9/apidocs
 JXURL http://download.eclipse.org/jetty/stable-9/xref
 GITURL https://raw.githubusercontent.com/eclipse/jetty.project/master
-GITBROWSEURL https://github.com/eclipse/jetty.project/master
+GITBROWSEURL https://github.com/eclipse/jetty.project/blob/master


### PR DESCRIPTION
Unfortunately none of the links in the documentation using GITBROWSEURL are valid (at least, not anymore). When linking to a raw file like GITURL does, /blob can be omitted, as it is currently.

This fixes the links.